### PR TITLE
Simplify VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,12 +10,7 @@
         "**/.fake": true,
         "**/packages": true,
         "**/node_modules": true,
-        "**/paket-files": true
-    },
-    "search.exclude": {
-        "**/node_modules": true,
         "**/bower_components": true,
-        "**/packages": true,
         "**/paket-files": true
     },
     "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
According to [VS Code documentation](https://code.visualstudio.com/docs/getstarted/settings), `search.exclude` inherits from `files.exclude` (Ctrl-F "inherits"). I removed duplicate entries, and only `bower_components` was left, which I also assume shouldn't be shown, so I moved that to `files.exclude` and removed `search.exclude` altogether.

Furthermore, I notice that the file has `"files.trimFinalNewlines": true`, but in https://github.com/MangelMaxime/fulma-demo/pull/16#issuecomment-434610572 you say that you always keep the newline. I do too. Should this line also be removed?